### PR TITLE
Use cart fetcher hook 13

### DIFF
--- a/app/api/cart/route.ts
+++ b/app/api/cart/route.ts
@@ -1,0 +1,113 @@
+import { addToCart, updateCart, removeFromCart, getCart } from "@/lib/shopify";
+import { isShopifyError } from "@/lib/type-guards";
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+function formatErrorMessage(err: Error): string {
+  return JSON.stringify(err, Object.getOwnPropertyNames(err));
+}
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const cartId = cookies().get("cartId")?.value;
+
+  if (!cartId?.length) {
+    return NextResponse.json(
+      { error: "Missing cartId" },
+      { status: 400 }
+    );
+  }
+  try {
+    const cart = await getCart(cartId);
+    return NextResponse.json({ status: 200, cart });
+  } catch (e) {
+    if (isShopifyError(e)) {
+      return NextResponse.json(
+        { message: formatErrorMessage(e.message) },
+        { status: e.status }
+      );
+    }
+
+    return NextResponse.json({ status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest): Promise<Response> {
+  const cartId = cookies().get("cartId")?.value;
+  const { merchandiseId } = await req.json();
+
+  if (!cartId?.length || !merchandiseId?.length) {
+    return NextResponse.json(
+      { error: "Missing cartId or variantId" },
+      { status: 400 }
+    );
+  }
+  try {
+    await addToCart(cartId, [{ merchandiseId, quantity: 1 }]);
+    return NextResponse.json({ status: 204 });
+  } catch (e) {
+    if (isShopifyError(e)) {
+      return NextResponse.json(
+        { message: formatErrorMessage(e.message) },
+        { status: e.status }
+      );
+    }
+
+    return NextResponse.json({ status: 500 });
+  }
+}
+
+export async function PUT(req: NextRequest): Promise<Response> {
+  const cartId = cookies().get("cartId")?.value;
+  const { variantId, quantity, lineId } = await req.json();
+
+  if (!cartId || !variantId || !quantity || !lineId) {
+    return NextResponse.json(
+      { error: "Missing cartId, variantId, lineId, or quantity" },
+      { status: 400 }
+    );
+  }
+  try {
+    await updateCart(cartId, [
+      {
+        id: lineId,
+        merchandiseId: variantId,
+        quantity,
+      },
+    ]);
+    return NextResponse.json({ status: 204 });
+  } catch (e) {
+    if (isShopifyError(e)) {
+      return NextResponse.json(
+        { message: formatErrorMessage(e.message) },
+        { status: e.status }
+      );
+    }
+
+    return NextResponse.json({ status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest): Promise<Response> {
+  const cartId = cookies().get("cartId")?.value;
+  const { lineId } = await req.json();
+
+  if (!cartId || !lineId) {
+    return NextResponse.json(
+      { error: "Missing cartId or lineId" },
+      { status: 400 }
+    );
+  }
+  try {
+    await removeFromCart(cartId, [lineId]);
+    return NextResponse.json({ status: 204 });
+  } catch (e) {
+    if (isShopifyError(e)) {
+      return NextResponse.json(
+        { message: formatErrorMessage(e.message) },
+        { status: e.status }
+      );
+    }
+
+    return NextResponse.json({ status: 500 });
+  }
+}

--- a/app/api/create-cart/route.ts
+++ b/app/api/create-cart/route.ts
@@ -1,0 +1,24 @@
+import { createCart } from "@/lib/shopify";
+import { isShopifyError } from "@/lib/type-guards";
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+function formatErrorMessage(err: Error): string {
+  return JSON.stringify(err, Object.getOwnPropertyNames(err));
+}
+
+export async function POST(req: NextRequest): Promise<Response> {
+  try {
+    const cart = await createCart();
+    return NextResponse.json({ status: 200, cart });
+  } catch (e) {
+    if (isShopifyError(e)) {
+      return NextResponse.json(
+        { message: formatErrorMessage(e.message) },
+        { status: e.status }
+      );
+    }
+
+    return NextResponse.json({ status: 500 });
+  }
+}

--- a/hooks/useCartFetcher.ts
+++ b/hooks/useCartFetcher.ts
@@ -1,0 +1,89 @@
+import { createCart, getCart } from "@/lib/shopify";
+import { Cart, CartItem } from "@/lib/shopify/types";
+import useCartStore from "@/store/cart-store";
+import { cookies } from "next/headers";
+import { useCookie } from "react-use";
+
+const useCartFetcher = () => {
+  const [, setCookie] = useCookie("cartId");
+  const cartId = cookies().get("cartId")?.value;
+  // If cart not created
+  if (!cartId) {
+    const createCart = async () => {
+      const response = await fetch(`/api/create-cart`, {
+        method: "POST",
+      });
+      if (response.status === 200) {
+        const data = await response.json();
+        setCookie(data.cart.id, {
+          path: "/",
+          sameSite: "strict",
+          secure: process.env.NODE_ENV === "production",
+        });
+      }
+    };
+
+    createCart();
+  }
+
+  const getStoreCart = async () => {
+    const response = await fetch(`/api/cart`, {
+      method: "GET",
+    });
+    if (response.status === 200) {
+      const data = await response.json()
+      useCartStore.setState({ cart: data.cart });
+    }
+  };
+
+  const addCatItem = async ({ variantId }: { variantId: string }) => {
+    const response = await fetch(`/api/cart`, {
+      method: "POST",
+      body: JSON.stringify({
+        merchandiseId: variantId,
+      }),
+    });
+
+    if (response.status === 204) {
+      getStoreCart();
+    }
+  };
+
+  const editCartItem = async ({
+    action,
+    item,
+  }: {
+    action: "plus" | "minus";
+    item: CartItem;
+  }) => {
+    const response = await fetch(`/api/cart`, {
+      method: action === "minus" && item.quantity - 1 === 0 ? "DELETE" : "PUT",
+      body: JSON.stringify({
+        lineId: item.id,
+        variantId: item.merchandise.id,
+        quantity: action === "plus" ? item.quantity + 1 : item.quantity - 1,
+      }),
+    });
+
+    if (response.status === 204) {
+      getStoreCart();
+    }
+  };
+
+  const deleteCartItem = async ({ item }: { item: CartItem }) => {
+    const response = await fetch(`/api/cart`, {
+      method: "DELETE",
+      body: JSON.stringify({
+        lineId: item.id,
+      }),
+    });
+
+    if (response.status === 204) {
+      getStoreCart();
+    }
+  };
+
+  return { editCartItem, getStoreCart, deleteCartItem, addCatItem };
+};
+
+export default useCartFetcher;

--- a/lib/shopify/mutations/cart.ts
+++ b/lib/shopify/mutations/cart.ts
@@ -1,0 +1,45 @@
+import { cartFragment } from "../queries/fragments";
+
+export const addToCartMutation = `#graphql
+  mutation addToCart($cartId: ID!, $lines: [CartLineInput!]!) {
+    cartLinesAdd(cartId: $cartId, lines: $lines) {
+      cart {
+        ...cart
+      }
+    }
+  }
+  ${cartFragment}
+`;
+
+export const createCartMutation = `#graphql
+  mutation createCart($lineItems: [CartLineInput!]) {
+    cartCreate(input: { lines: $lineItems }) {
+      cart {
+        ...cart
+      }
+    }
+  }
+  ${cartFragment}
+`;
+
+export const editCartItemsMutation = `#graphql
+  mutation editCartItems($cartId: ID!, $lines: [CartLineUpdateInput!]!) {
+    cartLinesUpdate(cartId: $cartId, lines: $lines) {
+      cart {
+        ...cart
+      }
+    }
+  }
+  ${cartFragment}
+`;
+
+export const removeFromCartMutation = `#graphql
+  mutation removeFromCart($cartId: ID!, $lineIds: [ID!]!) {
+    cartLinesRemove(cartId: $cartId, lineIds: $lineIds) {
+      cart {
+        ...cart
+      }
+    }
+  }
+  ${cartFragment}
+`;

--- a/lib/shopify/queries/cart.ts
+++ b/lib/shopify/queries/cart.ts
@@ -1,0 +1,10 @@
+import { cartFragment } from "./fragments";
+
+export const getCartQuery = `#graphql
+  query getCart($cartId: ID!) {
+    cart(id: $cartId) {
+      ...cart
+    }
+  }
+  ${cartFragment}
+`;

--- a/lib/shopify/queries/fragments.ts
+++ b/lib/shopify/queries/fragments.ts
@@ -72,3 +72,131 @@ export const PRODUCT_CARD_FRAGMENT = `#graphql
     }
   }
 `;
+
+export const imageFragment = `#graphql
+  fragment image on Image {
+    url
+    altText
+    width
+    height
+  }
+`;
+
+export const seoFragment = `#graphql
+  fragment seo on SEO {
+    description
+    title
+  }
+`;
+
+
+export const productFragment = `#graphql
+  fragment product on Product {
+    id
+    handle
+    availableForSale
+    title
+    description
+    descriptionHtml
+    options {
+      id
+      name
+      values
+    }
+    priceRange {
+      maxVariantPrice {
+        amount
+        currencyCode
+      }
+      minVariantPrice {
+        amount
+        currencyCode
+      }
+    }
+    variants(first: 250) {
+      edges {
+        node {
+          id
+          title
+          availableForSale
+          selectedOptions {
+            name
+            value
+          }
+          price {
+            amount
+            currencyCode
+          }
+        }
+      }
+    }
+    featuredImage {
+      ...image
+    }
+    images(first: 20) {
+      edges {
+        node {
+          ...image
+        }
+      }
+    }
+    seo {
+      ...seo
+    }
+    tags
+    updatedAt
+  }
+  ${imageFragment}
+  ${seoFragment}
+`;
+
+export const cartFragment = `#graphql
+  fragment cart on Cart {
+    id
+    checkoutUrl
+    cost {
+      subtotalAmount {
+        amount
+        currencyCode
+      }
+      totalAmount {
+        amount
+        currencyCode
+      }
+      totalTaxAmount {
+        amount
+        currencyCode
+      }
+    }
+    lines(first: 100) {
+      edges {
+        node {
+          id
+          quantity
+          cost {
+            totalAmount {
+              amount
+              currencyCode
+            }
+          }
+          merchandise {
+            ... on ProductVariant {
+              id
+              title
+              selectedOptions {
+                name
+                value
+              }
+              product {
+                ...product
+              }
+            }
+          }
+        }
+      }
+    }
+    totalQuantity
+  }
+  ${productFragment}
+`;
+

--- a/lib/shopify/types.ts
+++ b/lib/shopify/types.ts
@@ -674,3 +674,95 @@ export type ShopifyHeroOperation = {
     language?: string;
   };
 };
+
+
+
+export type ShopifyCartOperation = {
+  data: {
+    cart: ShopifyCart;
+  };
+  variables: {
+    cartId: string;
+  };
+};
+
+export type ShopifyCreateCartOperation = {
+  data: { cartCreate: { cart: ShopifyCart } };
+};
+
+export type ShopifyAddToCartOperation = {
+  data: {
+    cartLinesAdd: {
+      cart: ShopifyCart;
+    };
+  };
+  variables: {
+    cartId: string;
+    lines: {
+      merchandiseId: string;
+      quantity: number;
+    }[];
+  };
+};
+
+export type ShopifyRemoveFromCartOperation = {
+  data: {
+    cartLinesRemove: {
+      cart: ShopifyCart;
+    };
+  };
+  variables: {
+    cartId: string;
+    lineIds: string[];
+  };
+};
+
+export type ShopifyUpdateCartOperation = {
+  data: {
+    cartLinesUpdate: {
+      cart: ShopifyCart;
+    };
+  };
+  variables: {
+    cartId: string;
+    lines: {
+      id: string;
+      merchandiseId: string;
+      quantity: number;
+    }[];
+  };
+};
+
+
+export type ShopifyCart = {
+  id: string;
+  checkoutUrl: string;
+  cost: {
+    subtotalAmount: Money;
+    totalAmount: Money;
+    totalTaxAmount: Money;
+  };
+  lines: Connection<CartItem>;
+  totalQuantity: number;
+};
+
+export type Cart = Omit<ShopifyCart, "lines"> & {
+  lines: CartItem[];
+};
+
+export type CartItem = {
+  id: string;
+  quantity: number;
+  cost: {
+    totalAmount: Money;
+  };
+  merchandise: {
+    id: string;
+    title: string;
+    selectedOptions: {
+      name: string;
+      value: string;
+    }[];
+    product: Product;
+  };
+};

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-use": "^17.4.0",
     "storybook": "^7.0.12",
     "type-fest": "^3.10.0",
-    "typographic-base": "^1.0.4"
+    "typographic-base": "^1.0.4",
+    "zustand": "^4.3.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,7 @@ specifiers:
   typescript: 5.0.4
   typographic-base: ^1.0.4
   webpack: '>=5.0.0 <6.0.0'
+  zustand: ^4.3.8
 
 dependencies:
   '@babel/core': 7.21.8
@@ -77,6 +78,7 @@ devDependencies:
   storybook: 7.0.12
   type-fest: 3.10.0_typescript@5.0.4
   typographic-base: 1.0.4
+  zustand: 4.3.8_react@18.2.0
 
 packages:
 
@@ -10079,6 +10081,14 @@ packages:
       react-dom: 18.2.0_react@18.2.0
     dev: true
 
+  /use-sync-external-store/1.2.0_react@18.2.0:
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: true
+
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -10388,3 +10398,19 @@ packages:
 
   /zod/3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
+
+  /zustand/4.3.8_react@18.2.0:
+    resolution: {integrity: sha512-4h28KCkHg5ii/wcFFJ5Fp+k1J3gJoasaIbppdgZFO4BPJnsNxL0mQXBSFgOgAdCdBj35aDTPvdAJReTMntFPGg==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      immer: '>=9.0'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      immer:
+        optional: true
+      react:
+        optional: true
+    dependencies:
+      react: 18.2.0
+      use-sync-external-store: 1.2.0_react@18.2.0
+    dev: true

--- a/store/cart-store.ts
+++ b/store/cart-store.ts
@@ -1,0 +1,16 @@
+import { Cart } from "@/lib/shopify/types";
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+
+export interface ICartProps {
+  cart: Cart | null;
+}
+
+const initialState: ICartProps = {
+  cart: null,
+};
+
+const useCartStore = create(
+  devtools<ICartProps>(() => initialState, { name: "cart-store" })
+);
+export default useCartStore;


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Documentation change
- [x] Bug fix

## Summary of change

<!-- Please include a brief summary of the changes made in this PR. You should also include any screenshots or videos when applicable -->

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/hydrogen-nextjs/blob/main/CONTRIBUTING.md)
- [x] Changes for this new starter kit are being pushed to an integration branch instead of main
- [ ] All dependencies are version locked
- [x] This fix resolves #13 
- [x] I have verified the fix works and introduces no further errors

Carts are a big feature of Shopify and enable users to buy products. This hook enables users to interact with the cart. We need to make this work in Next.js land.

Upstream: https://github.com/Shopify/hydrogen/blob/2023-04/templates/demo-store/app/hooks/useCartFetchers.tsx

# Acceptance
- Hook should support all actions that would happen on a cart
  - add
  - remove
  - update items
  - added zustand for cart (Read-only)
-  Cannot copy hydrogen template verbatim b/c of differences between Remix & Next
