### PR TITLE
tdl:hotfix error account form

### DIFF
--- a/components/AccountForm.tsx
+++ b/components/AccountForm.tsx
@@ -100,7 +100,6 @@ function AccountForm({ customer }: IAccountForm) {
 		revalidatePath('/account');
 
 		if (!formError) {
-			revalidatePath('/account');
 			redirect('/account');
 		}
 	};

--- a/components/AccountForm.tsx
+++ b/components/AccountForm.tsx
@@ -97,6 +97,8 @@ function AccountForm({ customer }: IAccountForm) {
 			}
 		}
 
+		revalidatePath('/account');
+
 		if (!formError) {
 			revalidatePath('/account');
 			redirect('/account');

--- a/components/AddressForm.tsx
+++ b/components/AddressForm.tsx
@@ -112,7 +112,6 @@ function AddressForm({ isNewAddress, address, defaultAddress }: IAddressForm) {
 		revalidatePath('/account');
 
 		if (!formError) {
-			revalidatePath('/account');
 			redirect('/account');
 		}
 	};

--- a/components/AddressForm.tsx
+++ b/components/AddressForm.tsx
@@ -109,6 +109,8 @@ function AddressForm({ isNewAddress, address, defaultAddress }: IAddressForm) {
 			}
 		}
 
+		revalidatePath('/account');
+
 		if (!formError) {
 			revalidatePath('/account');
 			redirect('/account');


### PR DESCRIPTION
## Type of change

- [ ] Documentation change
- [x] Bug fix

## Summary of change

We need the revalidate outside the ifs cause otherwise we won't show the form errors for both account detail form and addresses forms

## Checklist

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/hydrogen-nextjs/blob/main/CONTRIBUTING.md)
- [x] This starter kit has been approved by the maintainers
- [x] Changes for this new starter kit are being pushed to an integration branch instead of main
- [x] I have verified the fix works and introduces no further errors
